### PR TITLE
Allow edit of priority field on EditCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
@@ -46,7 +47,8 @@ public class EditCommand extends Command {
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
-            + "[" + PREFIX_REMARK + "REMARK]"
+            + "[" + PREFIX_REMARK + "REMARK] "
+            + "[" + PREFIX_PRIORITY + "PRIORITY] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
@@ -168,7 +170,7 @@ public class EditCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, phone, email, address, remark, tags);
+            return CollectionUtil.isAnyNonNull(name, phone, email, address, remark, priority, tags);
         }
 
         public void setName(Name name) {
@@ -252,6 +254,8 @@ public class EditCommand extends Command {
                     && Objects.equals(phone, otherEditPersonDescriptor.phone)
                     && Objects.equals(email, otherEditPersonDescriptor.email)
                     && Objects.equals(address, otherEditPersonDescriptor.address)
+                    && Objects.equals(priority, otherEditPersonDescriptor.priority)
+                    && Objects.equals(remark, otherEditPersonDescriptor.remark)
                     && Objects.equals(tags, otherEditPersonDescriptor.tags);
         }
 

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
@@ -34,7 +35,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG,
-                        PREFIX_REMARK);
+                        PREFIX_REMARK, PREFIX_PRIORITY);
 
         Index index;
 
@@ -44,7 +45,8 @@ public class EditCommandParser implements Parser<EditCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+                PREFIX_REMARK, PREFIX_PRIORITY);
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
 
@@ -62,6 +64,9 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
         if (argMultimap.getValue(PREFIX_REMARK).isPresent()) {
             editPersonDescriptor.setRemark(ParserUtil.parseRemark(argMultimap.getValue(PREFIX_REMARK).get()));
+        }
+        if (argMultimap.getValue(PREFIX_PRIORITY).isPresent()) {
+            editPersonDescriptor.setPriority(ParserUtil.parsePriority(argMultimap.getValue(PREFIX_PRIORITY).get()));
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
 

--- a/src/main/java/seedu/address/model/person/Age.java
+++ b/src/main/java/seedu/address/model/person/Age.java
@@ -1,5 +1,0 @@
-package seedu.address.model.person;
-
-public class Age {
-
-}

--- a/src/main/java/seedu/address/model/person/Age.java
+++ b/src/main/java/seedu/address/model/person/Age.java
@@ -1,0 +1,5 @@
+package seedu.address.model.person;
+
+public class Age {
+
+}

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
@@ -25,6 +26,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Priority;
 import seedu.address.model.person.Remark;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
@@ -33,6 +35,8 @@ import seedu.address.testutil.PersonBuilder;
  * Contains integration tests (interaction with the Model) and unit tests for EditCommand.
  */
 public class EditCommandTest {
+
+    private final Helper helper = new Helper();
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
@@ -71,43 +75,20 @@ public class EditCommandTest {
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 
-    private void execute_specifiedRemarkField_shouldModifyRemark(String remarkString) {
-        Remark remark = new Remark(remarkString);
-
-        Person personToBeEdited = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-
-        Person personToBeExpected = new Person(
-                personToBeEdited.getName(),
-                personToBeEdited.getPhone(),
-                personToBeEdited.getEmail(),
-                personToBeEdited.getAddress(),
-                personToBeEdited.getPriority(),
-                remark,
-                personToBeEdited.getTags());
-
-        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder()
-                .withRemark(remark.value)
-                .build();
-
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
-
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setPerson(personToBeEdited, personToBeExpected);
-
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS,
-                Messages.format(personToBeExpected));
-
-        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
-    }
-
     @Test
     public void execute_specifiedRemarkField_shouldModifyRemark() {
-        execute_specifiedRemarkField_shouldModifyRemark("This is a remark!");
+        helper.execute_specifiedRemarkField_shouldModifyRemark("This is a remark!");
     }
 
     @Test
     public void execute_specifiedEmptyRemarkField_shouldModifyRemark() {
-        execute_specifiedRemarkField_shouldModifyRemark("");
+        helper.execute_specifiedRemarkField_shouldModifyRemark("");
+    }
+
+    @Test void execute_specifiedPriorityField_shouldModifyPriority() {
+        for (Priority priority : Priority.values()) {
+            helper.execute_specifiedPriorityField_shouldModifyPriority(priority);
+        }
     }
 
     @Test
@@ -221,4 +202,66 @@ public class EditCommandTest {
         assertEquals(expected, editCommand.toString());
     }
 
+    private class Helper {
+
+        public void execute_specifiedRemarkField_shouldModifyRemark(String remarkString) {
+            Remark remark = new Remark(remarkString);
+
+            Person personToBeEdited = EditCommandTest.this.model.getFilteredPersonList()
+                    .get(INDEX_FIRST_PERSON.getZeroBased());
+
+            Person personToBeExpected = new Person(
+                    personToBeEdited.getName(),
+                    personToBeEdited.getPhone(),
+                    personToBeEdited.getEmail(),
+                    personToBeEdited.getAddress(),
+                    personToBeEdited.getPriority(),
+                    remark,
+                    personToBeEdited.getTags());
+
+            EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder()
+                    .withRemark(remark.value)
+                    .build();
+
+            EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
+
+            Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+            expectedModel.setPerson(personToBeEdited, personToBeExpected);
+
+            String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS,
+                    Messages.format(personToBeExpected));
+
+            assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+        }
+
+        public void execute_specifiedPriorityField_shouldModifyPriority(Priority priority) {
+            assertNotNull(priority);
+
+            Person personToBeEdited = EditCommandTest.this.model.getFilteredPersonList()
+                    .get(INDEX_FIRST_PERSON.getZeroBased());
+
+            Person personToBeExpected = new Person(
+                    personToBeEdited.getName(),
+                    personToBeEdited.getPhone(),
+                    personToBeEdited.getEmail(),
+                    personToBeEdited.getAddress(),
+                    priority,
+                    personToBeEdited.getRemark(),
+                    personToBeEdited.getTags());
+
+            EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder()
+                    .withPriority(priority)
+                    .build();
+
+            EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
+
+            Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+            expectedModel.setPerson(personToBeEdited, personToBeExpected);
+
+            String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS,
+                    Messages.format(personToBeExpected));
+
+            assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+        }
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -85,7 +85,8 @@ public class EditCommandTest {
         helper.execute_specifiedRemarkField_shouldModifyRemark("");
     }
 
-    @Test void execute_specifiedPriorityField_shouldModifyPriority() {
+    @Test
+    public void execute_specifiedPriorityField_shouldModifyPriority() {
         for (Priority priority : Priority.values()) {
             helper.execute_specifiedPriorityField_shouldModifyPriority(priority);
         }
@@ -207,7 +208,7 @@ public class EditCommandTest {
         public void execute_specifiedRemarkField_shouldModifyRemark(String remarkString) {
             Remark remark = new Remark(remarkString);
 
-            Person personToBeEdited = EditCommandTest.this.model.getFilteredPersonList()
+            Person personToBeEdited = model.getFilteredPersonList()
                     .get(INDEX_FIRST_PERSON.getZeroBased());
 
             Person personToBeExpected = new Person(
@@ -225,11 +226,9 @@ public class EditCommandTest {
 
             EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
 
-            Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-            expectedModel.setPerson(personToBeEdited, personToBeExpected);
+            Model expectedModel = generateExpectedModel(personToBeEdited, personToBeExpected);
 
-            String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS,
-                    Messages.format(personToBeExpected));
+            String expectedMessage = generateExpectedSuccessMessage(personToBeExpected);
 
             assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
         }
@@ -237,7 +236,7 @@ public class EditCommandTest {
         public void execute_specifiedPriorityField_shouldModifyPriority(Priority priority) {
             assertNotNull(priority);
 
-            Person personToBeEdited = EditCommandTest.this.model.getFilteredPersonList()
+            Person personToBeEdited = model.getFilteredPersonList()
                     .get(INDEX_FIRST_PERSON.getZeroBased());
 
             Person personToBeExpected = new Person(
@@ -255,13 +254,22 @@ public class EditCommandTest {
 
             EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
 
-            Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-            expectedModel.setPerson(personToBeEdited, personToBeExpected);
+            Model expectedModel = generateExpectedModel(personToBeEdited, personToBeExpected);
 
-            String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS,
-                    Messages.format(personToBeExpected));
+            String expectedMessage = generateExpectedSuccessMessage(personToBeExpected);
 
             assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
         }
+    }
+
+    private Model generateExpectedModel(Person personToBeEdited, Person personToBeExpected) {
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(personToBeEdited, personToBeExpected);
+        return expectedModel;
+    }
+
+    private String generateExpectedSuccessMessage(Person personToBeExpected) {
+        return String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS,
+                Messages.format(personToBeExpected));
     }
 }

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -10,6 +10,7 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.Priority;
 import seedu.address.model.person.Remark;
 import seedu.address.model.tag.Tag;
 
@@ -79,6 +80,14 @@ public class EditPersonDescriptorBuilder {
      */
     public EditPersonDescriptorBuilder withRemark(String remark) {
         descriptor.setRemark(new Remark(remark));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Priority} of the {@code EditPersonDescriptor} that we are building.
+     */
+    public EditPersonDescriptorBuilder withPriority(Priority priority) {
+        descriptor.setPriority(priority);
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -4,6 +4,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
@@ -51,6 +52,8 @@ public class PersonUtil {
         descriptor.getPhone().ifPresent(phone -> sb.append(PREFIX_PHONE).append(phone.value).append(" "));
         descriptor.getEmail().ifPresent(email -> sb.append(PREFIX_EMAIL).append(email.value).append(" "));
         descriptor.getAddress().ifPresent(address -> sb.append(PREFIX_ADDRESS).append(address.value).append(" "));
+        descriptor.getRemark().ifPresent(remark -> sb.append(PREFIX_REMARK).append(remark.value).append(" "));
+        descriptor.getPriority().ifPresent(priority -> sb.append(PREFIX_PRIORITY).append(priority).append(" "));
         if (descriptor.getTags().isPresent()) {
             Set<Tag> tags = descriptor.getTags().get();
             if (tags.isEmpty()) {


### PR DESCRIPTION
Resolves #46. 

This commit allows user to edit the priority field on `Person` class.
The user may edit the priority field by typing `edit INDEX pri/ priority_value"`, e.g. `edit 1 pri/ HIGH`.