### PR TITLE
Add test case to HelpCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+
 import seedu.address.model.Model;
 
 /**
@@ -27,6 +29,7 @@ public class HelpCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
+        requireNonNull(model);
         if (usage.isEmpty()) {
             return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
         } else {

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -23,19 +23,19 @@ public class HelpCommandTest {
         assertCommandSuccess(new HelpCommand(AddCommand.MESSAGE_USAGE),
                 model, expectedCommandResultAdd, expectedModel);
 
-        CommandResult expectedCommandResultClear = new CommandResult(AddCommand.MESSAGE_USAGE,
+        CommandResult expectedCommandResultClear = new CommandResult(ClearCommand.MESSAGE_USAGE,
                 false, false);
-        assertCommandSuccess(new HelpCommand(AddCommand.MESSAGE_USAGE),
+        assertCommandSuccess(new HelpCommand(ClearCommand.MESSAGE_USAGE),
                 model, expectedCommandResultClear, expectedModel);
 
-        CommandResult expectedCommandResultDelete = new CommandResult(AddCommand.MESSAGE_USAGE,
+        CommandResult expectedCommandResultDelete = new CommandResult(DeleteCommand.MESSAGE_USAGE,
                 false, false);
-        assertCommandSuccess(new HelpCommand(AddCommand.MESSAGE_USAGE),
+        assertCommandSuccess(new HelpCommand(DeleteCommand.MESSAGE_USAGE),
                 model, expectedCommandResultDelete, expectedModel);
 
-        CommandResult expectedCommandResultEdit = new CommandResult(AddCommand.MESSAGE_USAGE,
+        CommandResult expectedCommandResultEdit = new CommandResult(EditCommand.MESSAGE_USAGE,
                 false, false);
-        assertCommandSuccess(new HelpCommand(AddCommand.MESSAGE_USAGE),
+        assertCommandSuccess(new HelpCommand(EditCommand.MESSAGE_USAGE),
                 model, expectedCommandResultEdit, expectedModel);
     }
 

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -14,7 +14,29 @@ public class HelpCommandTest {
 
     @Test
     public void execute_help_success() {
-        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE,
+                true, false);
         assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
+
+        CommandResult expectedCommandResultAdd = new CommandResult(AddCommand.MESSAGE_USAGE,
+                false, false);
+        assertCommandSuccess(new HelpCommand(AddCommand.MESSAGE_USAGE),
+                model, expectedCommandResultAdd, expectedModel);
+
+        CommandResult expectedCommandResultClear = new CommandResult(AddCommand.MESSAGE_USAGE,
+                false, false);
+        assertCommandSuccess(new HelpCommand(AddCommand.MESSAGE_USAGE),
+                model, expectedCommandResultClear, expectedModel);
+
+        CommandResult expectedCommandResultDelete = new CommandResult(AddCommand.MESSAGE_USAGE,
+                false, false);
+        assertCommandSuccess(new HelpCommand(AddCommand.MESSAGE_USAGE),
+                model, expectedCommandResultDelete, expectedModel);
+
+        CommandResult expectedCommandResultEdit = new CommandResult(AddCommand.MESSAGE_USAGE,
+                false, false);
+        assertCommandSuccess(new HelpCommand(AddCommand.MESSAGE_USAGE),
+                model, expectedCommandResultEdit, expectedModel);
     }
+
 }


### PR DESCRIPTION
Invalid input is handled by HelpCommandParser and HelpCommand only passes the input message as the result shown on the GUI