### PR TITLE
Add person household income

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -46,6 +46,8 @@ public class Messages {
                 .append(person.getAddress())
                 .append("; Date of birth: ")
                 .append(person.getDateOfBirth())
+                .append("; Income: ")
+                .append(person.getIncome())
                 .append("; Priority: ")
                 .append(person.getPriority());
 

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -33,7 +33,6 @@ public class AddCommand extends Command {
             + PREFIX_DATE_OF_BIRTH + "DATE OF BIRTH "
             + "[" + PREFIX_PRIORITY + "PRIORITY = LOW] "
             + "[" + PREFIX_REMARK + "REMARK] "
-            + "[" + PREFIX_DATE_OF_BIRTH + "DATE OF BIRTH] "
             + "[" + PREFIX_INCOME + "INCOME = 0] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE_OF_BIRTH;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INCOME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
@@ -32,6 +33,7 @@ public class AddCommand extends Command {
             + "[" + PREFIX_PRIORITY + "PRIORITY = LOW] "
             + "[" + PREFIX_REMARK + "REMARK] "
             + "[" + PREFIX_DATE_OF_BIRTH + "DATE OF BIRTH] "
+            + "[" + PREFIX_INCOME + "INCOME = 0] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -26,6 +26,7 @@ import seedu.address.model.Model;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.DateOfBirth;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.Income;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -109,10 +110,11 @@ public class EditCommand extends Command {
         Priority updatedPriority = editPersonDescriptor.getPriority().orElse(personToEdit.getPriority());
         Remark updatedRemark = editPersonDescriptor.getRemark().orElse(personToEdit.getRemark());
         DateOfBirth updatedDateOfBirth = editPersonDescriptor.getDateOfBirth().orElse(personToEdit.getDateOfBirth());
+        Income updatedIncome = editPersonDescriptor.getIncome().orElse(personToEdit.getIncome());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
 
         return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress,
-                updatedPriority, updatedRemark, updatedDateOfBirth, updatedTags);
+                updatedPriority, updatedRemark, updatedDateOfBirth, updatedIncome, updatedTags);
     }
 
     @Override
@@ -151,6 +153,7 @@ public class EditCommand extends Command {
         private Priority priority;
         private Remark remark;
         private DateOfBirth dateOfBirth;
+        private Income income;
         private Set<Tag> tags;
 
         public EditPersonDescriptor() {}
@@ -231,6 +234,14 @@ public class EditCommand extends Command {
 
         public Optional<DateOfBirth> getDateOfBirth() {
             return Optional.ofNullable(dateOfBirth);
+        }
+
+        public void setIncome(Income income) {
+            this.income = income;
+        }
+
+        public Optional<Income> getIncome() {
+            return Optional.ofNullable(income);
         }
 
         /**

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -4,6 +4,7 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE_OF_BIRTH;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INCOME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
@@ -18,6 +19,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.DateOfBirth;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.Income;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -39,7 +41,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(
                         args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
-                        PREFIX_PRIORITY, PREFIX_REMARK, PREFIX_DATE_OF_BIRTH, PREFIX_TAG);
+                        PREFIX_PRIORITY, PREFIX_REMARK, PREFIX_DATE_OF_BIRTH, PREFIX_INCOME, PREFIX_TAG);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL,
                 PREFIX_DATE_OF_BIRTH)
@@ -57,9 +59,10 @@ public class AddCommandParser implements Parser<AddCommand> {
         Priority priority = ParserUtil.parsePriority(argMultimap.getValue(PREFIX_PRIORITY).orElse("LOW"));
         Remark remark = ParserUtil.parseRemark(argMultimap.getValue(PREFIX_REMARK).orElse(""));
         DateOfBirth dateOfBirth = ParserUtil.parseDateOfBirth(argMultimap.getValue(PREFIX_DATE_OF_BIRTH).get());
+        Income income = ParserUtil.parseIncome(argMultimap.getValue(PREFIX_INCOME).orElse(Income.EMPTY_VALUE_STRING));
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-        Person person = new Person(name, phone, email, address, priority, remark, dateOfBirth, tagList);
+        Person person = new Person(name, phone, email, address, priority, remark, dateOfBirth, income, tagList);
 
         return new AddCommand(person);
     }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -13,6 +13,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_PRIORITY = new Prefix("pri/");
     public static final Prefix PREFIX_REMARK = new Prefix("r/");
     public static final Prefix PREFIX_DATE_OF_BIRTH = new Prefix("dob/");
+    public static final Prefix PREFIX_INCOME = new Prefix("income/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
-
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -13,6 +13,7 @@ import seedu.address.model.person.Address;
 import seedu.address.model.person.Date;
 import seedu.address.model.person.DateOfBirth;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.Income;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Priority;
@@ -115,7 +116,6 @@ public class ParserUtil {
         }
     }
 
-
     /**
      * Parses a {@code String date} into a {@code Date}.
      * Leading and trailing whitespaces will be trimmed.
@@ -141,6 +141,18 @@ public class ParserUtil {
     public static Remark parseRemark(String remark) {
         requireNonNull(remark);
         return new Remark(remark.trim());
+    }
+
+    /**
+     * Parses a {@code String income} into a {@code Income}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code income} is invalid.
+     */
+    public static Income parseIncome(String income) throws ParseException {
+        requireNonNull(income);
+        String trimmedIncome = income.trim();
+        return new Income(trimmedIncome);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Income.java
+++ b/src/main/java/seedu/address/model/person/Income.java
@@ -1,0 +1,80 @@
+package seedu.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a Person's income in the address book.
+ * Guarantees: immutable; is valid as declared in {@link #isValidIncome(String)}
+ */
+public class Income {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Income is a non-negative floating point number with up to 2 decimal places e.g. 2.01, 0, 0.1";
+
+    public static final String VALIDATION_REGEX = "^[0-9]+(\\.[0-9]{1,2})?$";
+
+    public static final String EMPTY_VALUE_STRING = "0";
+
+    private final String value;
+
+    /**
+     * Constructs an {@code Income}.
+     * @param value The value of a peron's income
+     */
+    public Income(String value) {
+        checkArgument(isValidIncome(value), MESSAGE_CONSTRAINTS);
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public double toDouble() {
+        return Double.parseDouble(value);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("$%.2f", toDouble());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof Income otherIncome)) {
+            return false;
+        }
+
+        return toDouble() == otherIncome.toDouble();
+    }
+
+    @Override
+    public int hashCode() {
+        return Double.valueOf(value).hashCode();
+    }
+
+    /**
+     * Returns true if a given string is a valid income.
+     * @param test A string to be tested
+     * @return {@code true} if the string is valid, {@code false} otherwise
+     */
+    public static boolean isValidIncome(String test) {
+        requireNonNull(test);
+
+        if (!test.matches(VALIDATION_REGEX)) {
+            return false;
+        }
+
+        try {
+            Double.parseDouble(test);
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -26,13 +26,14 @@ public class Person {
     private final Priority priority;
     private final Remark remark;
     private final DateOfBirth dateOfBirth;
+    private final Income income;
     private final Set<Tag> tags = new HashSet<>();
 
     /**
      * Every field must be present and not null.
      */
-    public Person(Name name, Phone phone, Email email, Address address,
-                  Priority priority, Remark remark, DateOfBirth dateOfBirth, Set<Tag> tags) {
+    public Person(Name name, Phone phone, Email email, Address address, Priority priority,
+                  Remark remark, DateOfBirth dateOfBirth, Income income, Set<Tag> tags) {
         requireAllNonNull(name, phone, email, address, dateOfBirth, tags);
         this.name = name;
         this.phone = phone;
@@ -41,6 +42,7 @@ public class Person {
         this.priority = priority;
         this.remark = remark;
         this.dateOfBirth = dateOfBirth;
+        this.income = income;
         this.tags.addAll(tags);
     }
 
@@ -70,6 +72,10 @@ public class Person {
 
     public DateOfBirth getDateOfBirth() {
         return dateOfBirth;
+    }
+
+    public Income getIncome() {
+        return income;
     }
 
     /**
@@ -116,6 +122,7 @@ public class Person {
                 && priority.equals(otherPerson.priority)
                 && remark.equals(otherPerson.remark)
                 && dateOfBirth.equals(otherPerson.dateOfBirth)
+                && income.equals(otherPerson.income)
                 && tags.equals(otherPerson.tags);
     }
 
@@ -135,6 +142,7 @@ public class Person {
                 .add("priority", priority)
                 .add("remark", remark)
                 .add("dateOfBirth", dateOfBirth)
+                .add("income", income)
                 .add("tags", tags)
                 .toString();
     }

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -9,6 +9,7 @@ import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.DateOfBirth;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.Income;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -27,22 +28,22 @@ public class SampleDataUtil {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                 new Address("Blk 30 Geylang Street 29, #06-40"), Priority.HIGH, new Remark("Likes baseball"),
-                new DateOfBirth("1 Jan 2000"), getTagSet("friends")),
+                new DateOfBirth("1 Jan 2000"), new Income("3000"), getTagSet("friends")),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), Priority.MEDIUM, EMPTY_REMARK,
-                new DateOfBirth("1 Jan 2000"), getTagSet("colleagues", "friends")),
+                new DateOfBirth("1 Jan 2000"), new Income("1000"), getTagSet("colleagues", "friends")),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                 new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), Priority.LOW, EMPTY_REMARK,
-                new DateOfBirth("1 Jan 2000"), getTagSet("neighbours")),
+                new DateOfBirth("1 Jan 2000"), new Income("300"), getTagSet("neighbours")),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                 new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), Priority.HIGH, EMPTY_REMARK,
-                new DateOfBirth("1 Jan 2000"), getTagSet("family")),
+                new DateOfBirth("1 Jan 2000"), new Income("1400.00"), getTagSet("family")),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                 new Address("Blk 47 Tampines Street 20, #17-35"), Priority.MEDIUM, EMPTY_REMARK,
-                new DateOfBirth("1 Jan 2000"), getTagSet("classmates")),
+                new DateOfBirth("1 Jan 2000"), new Income("2000.50"), getTagSet("classmates")),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                 new Address("Blk 45 Aljunied Street 85, #11-31"), Priority.LOW, EMPTY_REMARK,
-                new DateOfBirth("1 Jan 2000"), getTagSet("colleagues"))
+                new DateOfBirth("1 Jan 2000"), new Income("1534.69"), getTagSet("colleagues"))
         };
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -13,6 +13,7 @@ import seedu.address.model.person.Address;
 import seedu.address.model.person.Date;
 import seedu.address.model.person.DateOfBirth;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.Income;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -34,6 +35,7 @@ class JsonAdaptedPerson {
     private final String priority;
     private final String remark;
     private final String dateOfBirth;
+    private final String income;
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
 
     /**
@@ -48,6 +50,7 @@ class JsonAdaptedPerson {
             @JsonProperty("priority") String priority,
             @JsonProperty("remark") String remark,
             @JsonProperty("dateOfBirth") String dateOfBirth,
+            @JsonProperty("income") String income,
             @JsonProperty("tags") List<JsonAdaptedTag> tags) {
         this.name = name;
         this.phone = phone;
@@ -56,6 +59,7 @@ class JsonAdaptedPerson {
         this.priority = priority;
         this.remark = remark;
         this.dateOfBirth = dateOfBirth;
+        this.income = income;
         if (tags != null) {
             this.tags.addAll(tags);
         }
@@ -72,6 +76,7 @@ class JsonAdaptedPerson {
         priority = source.getPriority().name();
         remark = source.getRemark().value;
         dateOfBirth = source.getDateOfBirth().getValue();
+        income = source.getIncome().getValue();
         tags.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .toList());
@@ -142,9 +147,11 @@ class JsonAdaptedPerson {
         }
         final DateOfBirth modelDateOfBirth = new DateOfBirth(dateOfBirth);
 
+        final Income modelIncome = new Income(income == null ? Income.EMPTY_VALUE_STRING : income);
+
         final Set<Tag> modelTags = new HashSet<>(personTags);
         return new Person(modelName, modelPhone, modelEmail, modelAddress, modelPriority, modelRemark,
-                modelDateOfBirth, modelTags);
+                modelDateOfBirth, modelIncome, modelTags);
     }
 
 }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -47,6 +47,8 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private Label dateOfBirth;
     @FXML
+    private Label householdIncome;
+    @FXML
     private FlowPane tags;
 
     /**
@@ -78,6 +80,8 @@ public class PersonCard extends UiPart<Region> {
                         getPersonAge(person)
                 )
         );
+
+        householdIncome.setText(String.format("[Household Income] %s", person.getIncome()));
 
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -37,6 +37,7 @@
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
       <Label fx:id="dateOfBirth" styleClass="cell_small_label" text="\$dateOfBirth" />
+      <Label fx:id="householdIncome" styleClass="cell_small_label" text="\$householdIncome" />
       <Label fx:id="remark" styleClass="cell_small_label" text="\$remark" />
     </VBox>
   </GridPane>

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DATE_OF_BIRTH_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.INCOME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -167,7 +168,7 @@ public class LogicManagerTest {
 
         // Triggers the saveAddressBook method by executing an add command
         String addCommand = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY
-                + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + DATE_OF_BIRTH_DESC_AMY;
+                + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + DATE_OF_BIRTH_DESC_AMY + INCOME_DESC_AMY;
         Person expectedPerson = new PersonBuilder(AMY).withTags().build();
         ModelManager expectedModel = new ModelManager();
         expectedModel.addPerson(expectedPerson);

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE_OF_BIRTH;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INCOME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
@@ -43,6 +44,8 @@ public class CommandTestUtil {
     public static final String VALID_REMARK_BOB = "Supports Manchester United.";
     public static final String VALID_DATE_OF_BIRTH_AMY = "1 Jan 2000";
     public static final String VALID_DATE_OF_BIRTH_BOB = "1 Jan 2000";
+    public static final String VALID_INCOME_AMY = "1500.32";
+    public static final String VALID_INCOME_BOB = "1300";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
 
@@ -60,6 +63,8 @@ public class CommandTestUtil {
     public static final String REMARK_DESC_BOB = " " + PREFIX_REMARK + VALID_REMARK_BOB;
     public static final String DATE_OF_BIRTH_DESC_AMY = " " + PREFIX_DATE_OF_BIRTH + VALID_DATE_OF_BIRTH_AMY;
     public static final String DATE_OF_BIRTH_DESC_BOB = " " + PREFIX_DATE_OF_BIRTH + VALID_DATE_OF_BIRTH_BOB;
+    public static final String INCOME_DESC_AMY = " " + PREFIX_INCOME + VALID_INCOME_AMY;
+    public static final String INCOME_DESC_BOB = " " + PREFIX_INCOME + VALID_INCOME_BOB;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
 
@@ -70,6 +75,7 @@ public class CommandTestUtil {
     public static final String INVALID_PRIORITY_DESC = " " + PREFIX_PRIORITY + "CRITICAL"; // no such priority
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
     public static final String INVALID_DATE_OF_BIRTH_DESC = " " + PREFIX_DATE_OF_BIRTH + "99 Dec 0001"; // invalid date
+    public static final String INVALID_INCOME_DESC = " " + PREFIX_INCOME + "-323.32323";
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";
 

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -219,6 +219,7 @@ public class EditCommandTest {
                     personToBeEdited.getPriority(),
                     remark,
                     personToBeEdited.getDateOfBirth(),
+                    personToBeEdited.getIncome(),
                     personToBeEdited.getTags());
 
             EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder()
@@ -248,6 +249,7 @@ public class EditCommandTest {
                     priority,
                     personToBeEdited.getRemark(),
                     personToBeEdited.getDateOfBirth(),
+                    personToBeEdited.getIncome(),
                     personToBeEdited.getTags());
 
             EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder()

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -7,6 +7,8 @@ import static seedu.address.logic.commands.CommandTestUtil.DATE_OF_BIRTH_DESC_AM
 import static seedu.address.logic.commands.CommandTestUtil.DATE_OF_BIRTH_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.INCOME_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.INCOME_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_DATE_OF_BIRTH_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
@@ -66,14 +68,15 @@ public class AddCommandParserTest {
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + PRIORITY_DESC_BOB + REMARK_DESC_BOB + DATE_OF_BIRTH_DESC_BOB + TAG_DESC_FRIEND,
+                + ADDRESS_DESC_BOB + PRIORITY_DESC_BOB + REMARK_DESC_BOB + DATE_OF_BIRTH_DESC_BOB + INCOME_DESC_BOB
+                + TAG_DESC_FRIEND,
                 new AddCommand(expectedPerson));
 
         // multiple tags - all accepted
         Person expectedPersonMultipleTags = new PersonBuilder(BOB).build();
         assertParseSuccess(parser,
                 NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + DATE_OF_BIRTH_DESC_BOB
-                        + PRIORITY_DESC_BOB + REMARK_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                        + PRIORITY_DESC_BOB + REMARK_DESC_BOB + INCOME_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
                 new AddCommand(expectedPersonMultipleTags));
     }
 
@@ -165,7 +168,7 @@ public class AddCommandParserTest {
         // zero tags and no remark
         Person expectedPerson = new PersonBuilder(AMY).withTags().build();
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
-                + DATE_OF_BIRTH_DESC_AMY,
+                + DATE_OF_BIRTH_DESC_AMY + INCOME_DESC_AMY,
                 new AddCommand(expectedPerson));
     }
 

--- a/src/test/java/seedu/address/model/person/IncomeTest.java
+++ b/src/test/java/seedu/address/model/person/IncomeTest.java
@@ -1,0 +1,20 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class IncomeTest {
+    @Test
+    public void constructor_invalidIncome_throwsIllegalArgumentException() {
+        String invalidIncome = "-1";
+        assertThrows(IllegalArgumentException.class, () -> new Income(invalidIncome));
+    }
+
+    @Test
+    public void constructor_validIncome_shouldSucceed() {
+        String validIncome = "3000.0";
+        assertDoesNotThrow(() -> new Income(validIncome));
+    }
+}

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -111,7 +111,8 @@ public class PersonTest {
                 + ALICE.getAddress() + ", priority="
                 + ALICE.getPriority() + ", remark="
                 + ALICE.getRemark() + ", dateOfBirth="
-                + ALICE.getDateOfBirth() + ", tags="
+                + ALICE.getDateOfBirth() + ", income="
+                + ALICE.getIncome() + ", tags="
                 + ALICE.getTags() + "}";
         assertEquals(expected, ALICE.toString());
     }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -28,6 +28,7 @@ public class JsonAdaptedPersonTest {
     private static final String INVALID_TAG = "#friend";
     // December is not a valid input, use Dec or dec instead
     private static final String INVALID_DATE_OF_BIRTH = "31 December 2022";
+    private static final String INVALID_INCOME = "-1929";
 
     private static final String VALID_NAME = BENSON.getName().toString();
     private static final String VALID_PHONE = BENSON.getPhone().toString();
@@ -35,7 +36,9 @@ public class JsonAdaptedPersonTest {
     private static final String VALID_ADDRESS = BENSON.getAddress().toString();
     private static final String VALID_PRIORITY = BENSON.getPriority().toString();
     private static final String VALID_REMARK = BENSON.getRemark().toString();
+    private static final String VALID_INCOME = BENSON.getIncome().toString();
     private static final String VALID_DATE_OF_BIRTH = BENSON.getDateOfBirth().getValue();
+
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
@@ -50,7 +53,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        VALID_PRIORITY, VALID_REMARK, VALID_DATE_OF_BIRTH, VALID_TAGS);
+                        VALID_PRIORITY, VALID_REMARK, VALID_DATE_OF_BIRTH, VALID_INCOME, VALID_TAGS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -59,7 +62,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        VALID_PRIORITY, VALID_REMARK, VALID_DATE_OF_BIRTH, VALID_TAGS);
+                        VALID_PRIORITY, VALID_REMARK, VALID_DATE_OF_BIRTH, VALID_INCOME, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -68,7 +71,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        VALID_PRIORITY, VALID_REMARK, VALID_DATE_OF_BIRTH, VALID_TAGS);
+                        VALID_PRIORITY, VALID_REMARK, VALID_DATE_OF_BIRTH, VALID_INCOME, VALID_TAGS);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -77,7 +80,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS,
-                        VALID_PRIORITY, VALID_REMARK, VALID_DATE_OF_BIRTH, VALID_TAGS);
+                        VALID_PRIORITY, VALID_REMARK, VALID_DATE_OF_BIRTH, VALID_INCOME, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -86,7 +89,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS,
-                        VALID_PRIORITY, VALID_REMARK, VALID_DATE_OF_BIRTH, VALID_TAGS);
+                        VALID_PRIORITY, VALID_REMARK, VALID_DATE_OF_BIRTH, VALID_INCOME, VALID_TAGS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -95,7 +98,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS,
-                        VALID_PRIORITY, VALID_REMARK, VALID_DATE_OF_BIRTH, VALID_TAGS);
+                        VALID_PRIORITY, VALID_REMARK, VALID_DATE_OF_BIRTH, VALID_INCOME, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -104,7 +107,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS,
-                        VALID_PRIORITY, VALID_REMARK, VALID_DATE_OF_BIRTH, VALID_TAGS);
+                        VALID_PRIORITY, VALID_REMARK, VALID_DATE_OF_BIRTH, VALID_INCOME, VALID_TAGS);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -113,7 +116,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_nullAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null,
-                        VALID_PRIORITY, VALID_REMARK, VALID_DATE_OF_BIRTH, VALID_TAGS);
+                        VALID_PRIORITY, VALID_REMARK, VALID_DATE_OF_BIRTH, VALID_INCOME, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -122,7 +125,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidPriority_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        INVALID_PRIORITY, VALID_REMARK, VALID_DATE_OF_BIRTH, VALID_TAGS);
+                        INVALID_PRIORITY, VALID_REMARK, VALID_DATE_OF_BIRTH, VALID_INCOME, VALID_TAGS);
         String expectedMessage = Priority.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -131,7 +134,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_nullPriority_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        null, VALID_REMARK, VALID_DATE_OF_BIRTH, VALID_TAGS);
+                        null, VALID_REMARK, VALID_DATE_OF_BIRTH, VALID_INCOME, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Priority.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -140,7 +143,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidAge_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        VALID_PRIORITY, VALID_REMARK, INVALID_DATE_OF_BIRTH, VALID_TAGS);
+                        VALID_PRIORITY, VALID_REMARK, INVALID_DATE_OF_BIRTH, VALID_INCOME, VALID_TAGS);
         String expectedMessage = Date.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -149,7 +152,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_nullAge_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        VALID_PRIORITY, VALID_REMARK, null, VALID_TAGS);
+                        VALID_PRIORITY, VALID_REMARK, null, VALID_INCOME, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Date.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -160,7 +163,7 @@ public class JsonAdaptedPersonTest {
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        VALID_PRIORITY, VALID_REMARK, VALID_DATE_OF_BIRTH, invalidTags);
+                        VALID_PRIORITY, VALID_REMARK, VALID_DATE_OF_BIRTH, VALID_INCOME, invalidTags);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.DateOfBirth;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.Income;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -25,6 +26,7 @@ public class PersonBuilder {
     public static final String DEFAULT_ADDRESS = "123, Jurong West Ave 6, #08-111";
     public static final String DEFAULT_PRIORITY = "LOW";
     public static final String DEFAULT_REMARK = "";
+    public static final String DEFAULT_INCOME = "0";
     public static final String DEFAULT_DATE_OF_BIRTH = "1 Jan 2000";
 
     private Name name;
@@ -34,6 +36,7 @@ public class PersonBuilder {
     private Priority priority;
     private Remark remark;
     private DateOfBirth dateOfBirth;
+    private Income income;
     private Set<Tag> tags;
 
     /**
@@ -47,6 +50,7 @@ public class PersonBuilder {
         priority = Priority.valueOf(DEFAULT_PRIORITY);
         remark = new Remark(DEFAULT_REMARK);
         dateOfBirth = new DateOfBirth(DEFAULT_DATE_OF_BIRTH);
+        income = new Income(DEFAULT_INCOME);
         tags = new HashSet<>();
     }
 
@@ -61,6 +65,7 @@ public class PersonBuilder {
         priority = personToCopy.getPriority();
         remark = personToCopy.getRemark();
         dateOfBirth = personToCopy.getDateOfBirth();
+        income = personToCopy.getIncome();
         tags = new HashSet<>(personToCopy.getTags());
     }
 
@@ -121,6 +126,14 @@ public class PersonBuilder {
     }
 
     /**
+     * Sets the {@code income} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withIncome(String income) {
+        this.income = new Income(income);
+        return this;
+    }
+
+    /**
      * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code Person} that we are building.
      */
     public PersonBuilder withTags(String ... tags) {
@@ -129,7 +142,7 @@ public class PersonBuilder {
     }
 
     public Person build() {
-        return new Person(name, phone, email, address, priority, remark, dateOfBirth, tags);
+        return new Person(name, phone, email, address, priority, remark, dateOfBirth, income, tags);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -4,6 +4,8 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_INCOME_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_INCOME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
@@ -54,11 +56,11 @@ public class TypicalPersons {
     // Manually added - Person's details found in {@code CommandTestUtil}
     public static final Person AMY = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
             .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withTags(VALID_TAG_FRIEND)
-            .withDateOfBirth("1 Jan 2000").build();
+            .withDateOfBirth("1 Jan 2000").withIncome(VALID_INCOME_AMY).build();
     public static final Person BOB = new PersonBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
             .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withPriority(VALID_PRIORITY_BOB)
             .withRemark(VALID_REMARK_BOB).withDateOfBirth("1 Jan 2000").withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
-            .build();
+            .withIncome(VALID_INCOME_BOB).build();
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER
 


### PR DESCRIPTION
Closes #55 (along with PR #69)

With the `income` field, we can now include people's income using the income/INCOME parameter. This field is optional.

The `income` field in `Person` class is represented by a `Income` class which stores the income value as a String. `Income` class constructor accepts strings of non-negative floating point number with up to two decimal places, e.g. `1`, `1.0`, `1.10`.

The updated command format is `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS dob/DATE_OF_BIRTH [pri/PRIORITY = LOW] [r/REMARK] [income/INCOME] [t/TAG]…​`.

For example, `add n/John Doe p/98765432 e/johnd@example.com a/311, Clementi Ave 2, #02-25 dob/18 Jun 1999 pri/HIGH r/Promises to pay back next week. income/1234.59 t/friends t/owesMoney`.