### PR TITLE
Make previous command operation fail silently

### DIFF
--- a/src/main/java/seedu/address/logic/CommandHistory.java
+++ b/src/main/java/seedu/address/logic/CommandHistory.java
@@ -51,6 +51,11 @@ public class CommandHistory {
         if (currentIndex > 0) {
             currentIndex--;
         }
+
+        if (userInputHistory.isEmpty()) { // fails silently when no previous command is available
+            return "";
+        }
+
         return userInputHistory.get(currentIndex);
     }
 

--- a/src/test/java/seedu/address/logic/CommandHistoryTest.java
+++ b/src/test/java/seedu/address/logic/CommandHistoryTest.java
@@ -41,6 +41,10 @@ public class CommandHistoryTest {
         assertEquals("second command", history.getPrevious());
         assertEquals("first command", history.getPrevious());
         assertEquals("first command", history.getPrevious()); // Stay at earliest command
+
+        // Empty command history
+        history = new CommandHistory();
+        assertEquals("", history.getPrevious());
     }
 
     @Test


### PR DESCRIPTION
Fixes #131. Minor change to check for empty command history. 