### PR TITLE
Add sort command to help for user

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -17,7 +17,10 @@ public class SortCommand extends Command {
     public static final String COMMAND_WORD = "sort";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Sorts all persons in the address book according to the given parameter.\n"
+            + ": Sorts all persons in the address book according to the given parameter. "
+            + "Only one parameter can be used.\n"
+            + "Parameters: "
+            + "[name] [address] [priority] [income]\n"
             + "Example: " + COMMAND_WORD + " name";
 
     public static final String MESSAGE_SUCCESS = "Sorted all persons by %s";

--- a/src/main/java/seedu/address/logic/parser/HelpCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/HelpCommandParser.java
@@ -15,6 +15,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListAppointmentCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.StatisticsCommand;
+import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -92,6 +93,10 @@ public class HelpCommandParser implements Parser<HelpCommand> {
 
         case StatisticsCommand.COMMAND_WORD:
             message = StatisticsCommand.MESSAGE_USAGE;
+            break;
+
+        case SortCommand.COMMAND_WORD:
+            message = SortCommand.MESSAGE_USAGE;
             break;
 
         default:

--- a/src/main/java/seedu/address/logic/parser/HelpCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/HelpCommandParser.java
@@ -14,8 +14,8 @@ import seedu.address.logic.commands.GetCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListAppointmentCommand;
 import seedu.address.logic.commands.ListCommand;
-import seedu.address.logic.commands.StatisticsCommand;
 import seedu.address.logic.commands.SortCommand;
+import seedu.address.logic.commands.StatisticsCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -19,6 +19,7 @@ import seedu.address.logic.commands.GetCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.SchemeCommand;
+import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.commands.StatisticsCommand;
 
 /**
@@ -54,9 +55,12 @@ public class HelpWindow extends UiPart<Stage> {
 
     private static final String SCHEME_COMMAND = SchemeCommand.MESSAGE_USAGE + "\n";
 
+    private static final String SORT_COMMAND = SortCommand.MESSAGE_USAGE + "\n";
+
     private static final String HELP_COMMAND = HelpCommand.MESSAGE_USAGE + "\n";
     private static final String[] COMMANDS = {ADD_COMMAND, CLEAR_COMMAND, DELETE_COMMAND, EDIT_COMMAND,
-        FIND_COMMAND, GET_COMMAND, LIST_COMMAND, STATISTICS_COMMAND, SCHEME_COMMAND, HELP_COMMAND, EXIT_COMMAND};
+        FIND_COMMAND, GET_COMMAND, LIST_COMMAND, STATISTICS_COMMAND, SCHEME_COMMAND, SORT_COMMAND,
+            HELP_COMMAND, EXIT_COMMAND};
 
     @FXML
     private Button copyButton;

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -60,7 +60,7 @@ public class HelpWindow extends UiPart<Stage> {
     private static final String HELP_COMMAND = HelpCommand.MESSAGE_USAGE + "\n";
     private static final String[] COMMANDS = {ADD_COMMAND, CLEAR_COMMAND, DELETE_COMMAND, EDIT_COMMAND,
         FIND_COMMAND, GET_COMMAND, LIST_COMMAND, STATISTICS_COMMAND, SCHEME_COMMAND, SORT_COMMAND,
-            HELP_COMMAND, EXIT_COMMAND};
+        HELP_COMMAND, EXIT_COMMAND};
 
     @FXML
     private Button copyButton;

--- a/src/test/java/seedu/address/testutil/TypicalPastCommands.java
+++ b/src/test/java/seedu/address/testutil/TypicalPastCommands.java
@@ -59,7 +59,7 @@ public class TypicalPastCommands {
             createPastCommands(EXAMPLE_CLEAR, EXAMPLE_ADD, EXAMPLE_DELETE, EXAMPLE_DELETEA);
 
 
-    private static CommandHistory CURR_PAST_COMMANDS = new CommandHistory();
+    private static CommandHistory currentPastCommands = new CommandHistory();
     /**
      * Helper function to create CommandHistory with specified past commands.
      *
@@ -67,11 +67,11 @@ public class TypicalPastCommands {
      * @return CommandHistory with past commands.
      */
     public static CommandHistory createPastCommands(Command... pastCommands) {
-        CURR_PAST_COMMANDS = new CommandHistory();
+        currentPastCommands = new CommandHistory();
         for (int i = 0; i < pastCommands.length; i++) {
-            CURR_PAST_COMMANDS.add(pastCommands[i]);
+            currentPastCommands.add(pastCommands[i]);
         }
-        return CURR_PAST_COMMANDS;
+        return currentPastCommands;
 
     }
 

--- a/src/test/java/seedu/address/testutil/TypicalPastCommands.java
+++ b/src/test/java/seedu/address/testutil/TypicalPastCommands.java
@@ -59,7 +59,6 @@ public class TypicalPastCommands {
             createPastCommands(EXAMPLE_CLEAR, EXAMPLE_ADD, EXAMPLE_DELETE, EXAMPLE_DELETEA);
 
 
-    private static CommandHistory currentPastCommands = new CommandHistory();
     /**
      * Helper function to create CommandHistory with specified past commands.
      *
@@ -67,7 +66,7 @@ public class TypicalPastCommands {
      * @return CommandHistory with past commands.
      */
     public static CommandHistory createPastCommands(Command... pastCommands) {
-        currentPastCommands = new CommandHistory();
+        CommandHistory currentPastCommands = new CommandHistory();
         for (int i = 0; i < pastCommands.length; i++) {
             currentPastCommands.add(pastCommands[i]);
         }


### PR DESCRIPTION
This pull request fixes #149. Now, "help sort" will retrieve the sort command's usage message and the help window also shows the sort command. Additionally, noticed a minor style issue for the naming of a variable in the TypicalPastCommands class so just made a minor change to rectify that issue together with this pull request.